### PR TITLE
Tooltips

### DIFF
--- a/css/teiChrono.css
+++ b/css/teiChrono.css
@@ -86,7 +86,11 @@ tei-rs {
   border-bottom: 1px dotted black;
 }
 
-/* tei-expan {
+tei-rs:hover .tip {
+  display: block;
+}
+
+.tip {
   display: none;
   width: 120px;
   background-color: black;
@@ -96,10 +100,8 @@ tei-rs {
   padding: 5px 0;
 
   /* Position the tooltip */
-  /* position: absolute;
+  position: absolute; 
   z-index: 1;
 }
 
- tei-rs:hover + tei-expan {
-   display: block;
-}
+

--- a/js/behaviors.js
+++ b/js/behaviors.js
@@ -1,16 +1,19 @@
 var behaviors = {
   "tei": {
-    "rs": function (rs) {
-      let tooltip = document.createElement("span");
-      tooltip.setAttribute("class", "tip");
-      let expan = document.querySelector(rs.getAttribute("ref") + " tei-expan");
-      if (expan) {
-        tooltip.innerHTML = expan.innerHTML;
-      } else {
-        console.log("Can't find " + rs.getAttribute("ref"));
-      }
-      rs.appendChild(tooltip);
-    },
+    "rs": [
+      ["[ref]", function (rs) {
+          let tooltip = document.createElement("span");
+          tooltip.setAttribute("class", "tip");
+          let expan = document.querySelector(rs.getAttribute("ref") + " tei-expan");
+          if (expan) {
+            tooltip.innerHTML = expan.innerHTML;
+          } else {
+            console.log("Can't find " + rs.getAttribute("ref"));
+          }
+          rs.appendChild(tooltip);
+        }
+      ]
+    ],
     "table": function(elt) {
       let table = document.createElement("table");
       table.innerHTML = elt.innerHTML;

--- a/js/behaviors.js
+++ b/js/behaviors.js
@@ -1,5 +1,16 @@
 var behaviors = {
   "tei": {
+    "rs": function (rs) {
+      let tooltip = document.createElement("span");
+      tooltip.setAttribute("class", "tip");
+      let expan = document.querySelector(rs.getAttribute("ref") + " tei-expan");
+      if (expan) {
+        tooltip.innerHTML = expan.innerHTML;
+      } else {
+        console.log("Can't find " + rs.getAttribute("ref"));
+      }
+      rs.appendChild(tooltip);
+    },
     "table": function(elt) {
       let table = document.createElement("table");
       table.innerHTML = elt.innerHTML;

--- a/xslt/groupingHoldingInstitutions.xsl
+++ b/xslt/groupingHoldingInstitutions.xsl
@@ -6,13 +6,7 @@
   exclude-result-prefixes="xs"
   version="3.0">
   <xsl:output indent="yes"/>
-
-  <!-- This just speeds up the process of grabbing rows by <abbr> a little -->
-  <xsl:key name="INSTITUTIONS" match="t:abbr" use="t:abbr/normalize-space()"/>
-
-  <!-- This is another key to select the references to Institution IDs in cell 9-->
-  <xsl:key name="INSTITUTIONIDS" match="t:div[type="abbr"]" use="p@xml:id/normalize-space()"/>"
-
+  
   <!-- "Identity transform" template. Copies everything but the <text> -->
   <xsl:template match="node()|@*|*|processing-instruction()|comment()">
     <xsl:copy>
@@ -22,8 +16,6 @@
 
   <!-- Matches the <text> and puts in a list instead the original content-->
   <xsl:template match="t:text">
-    <!-- Gets a list of abbreviations that occur in <abbr> -->
-    <xsl:variable name="institutions" select="sort(distinct-values(//t:abbr/normalize-space()))"/>
     <!-- <xsl:for-each> changes the context (what's accessible to XPath).
       We want a copy so we can get back out of our place list when we're
       iterating over it to the main document -->
@@ -32,13 +24,15 @@
       <body>
         <list xml:id="institutions" type="firstList">
           <head xml:id="headInstitutions">Holding Institutions</head>
-          <xsl:for-each select="$institutions">
-            <item n="1institutions"><abbr target="#{@xml:id}"><xsl:value-of select="."/></abbr>
-              <list type="secondList">
+          <xsl:for-each select="id('dAbbr')//t:p">
+            <xsl:sort select="t:abbr"/>
+            <xsl:variable name="ref">#<xsl:value-of select="@xml:id"/></xsl:variable>
+            <item n="1institutions"><ref target="#{@xml:id}"><xsl:apply-templates select=".//t:abbr/node()"/></ref>
+              <list type="holdings">
                 <!-- Go and get each cell 9 where xml:id of institution is and display the name in cell 4-->
-                <xsl:for-each select="$context/key('INSTITUTIONIDS',current())">
-                  <xsl:sort select="normalize-space(t:cell[@n='4'])"></xsl:sort>
-                  <item><ref target="pages/chrono.html#{@xml:id}"><xsl:apply-templates select="t:cell[@n='4']/node()"/></ref></item>
+                <xsl:for-each select="$context//t:rs[@ref=$ref]">
+                  <xsl:sort select="normalize-space(ancestor::t:row/t:cell[@n='4'])"/>
+                  <item><ref target="pages/chrono.html#{ancestor::t:row[1]/@xml:id}"><xsl:apply-templates select="ancestor::t:row/t:cell[@n='4']/node()"/></ref></item>
                 </xsl:for-each>
               </list>
             </item>


### PR DESCRIPTION
Hi Adam,

This adds a tooltip function to `<rs>` elements that have a valid `@ref`. It does nothing if there isn't a ref attribute, and if it has one, but it points to a nonexistent id, then it logs that as an error in the console. I ran into a bit of trouble because Bootstrap has its own tooltip functionality (which uses the `.tooltip` class), but you have to include the right JavaScript to enable it. It wouldn't be hard to adjust things to work with that instead. But that's why I named the class "tip" instead of "tooltip", because the Bootstrap CSS gets in the way.